### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build, Package and Release
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/xixogo5105/uiptv/security/code-scanning/30](https://github.com/xixogo5105/uiptv/security/code-scanning/30)

To address this issue, you should add a `permissions` block to the workflow to limit the GITHUB_TOKEN permissions. Since this workflow does not appear to require any write operations (it only checks out code, sets up Java, builds artifacts, and uploads them), the minimal permission required is likely `contents: read`. This should be done at the root level of the workflow YAML file—directly after the workflow's name and before the `on:` block—so it applies to all jobs unless overridden. No further changes or dependencies are required, and no impact on existing functionality is expected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
